### PR TITLE
integrate catch2 framework and add an example

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,3 +12,9 @@ http_archive(
 load("@rules_cuda//cuda:repositories.bzl", "register_detected_cuda_toolchains", "rules_cuda_dependencies")
 rules_cuda_dependencies()
 register_detected_cuda_toolchains()
+
+http_archive(
+    name = "catch2",
+    urls = ["https://github.com/catchorg/Catch2/archive/refs/tags/v3.6.0.zip"], 
+    strip_prefix = "Catch2-3.6.0",  
+)

--- a/examples/test/BUILD.bazel
+++ b/examples/test/BUILD.bazel
@@ -1,0 +1,8 @@
+cc_test(
+    name = "simple_test",
+    srcs = ["simple_test.cpp"], 
+    deps = [
+        "@catch2//:catch2",        
+        "@catch2//:catch2_main",   
+    ],
+)

--- a/examples/test/simple_test.cc
+++ b/examples/test/simple_test.cc
@@ -1,0 +1,6 @@
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Framework integration test", "[integration]") {
+    REQUIRE(1 + 1 == 2);
+    REQUIRE(std::string("Hello") + " World" == "Hello World");
+}


### PR DESCRIPTION
Added `catch2` as an external dependency so that we dont have to do version control on `catch2` source code. This seems to be working without issues. 