### PR TITLE
Update SSH Key Mount Path Based on User (root or ian)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,6 @@ FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 # Set the working directory
 WORKDIR /shunya
 
-
-# Add safe directory for git to avoid dubious ownership warnings
-RUN git config --global --add safe.directory /shunya
-
-
 # Install basic dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -41,6 +36,10 @@ RUN curl -o /etc/bash_completion.d/git-completion.bash https://raw.githubusercon
 
 # Enable autocomplete in Bash for all users
 RUN echo "source /etc/bash_completion.d/git-completion.bash" >> /etc/bash.bashrc
+
+# Add safe directory for git to avoid dubious ownership warnings
+RUN git config --global --add safe.directory /shunya
+
 
 ARG USER=ian
 ARG GROUP=prajnyanam

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,11 @@ FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 # Set the working directory
 WORKDIR /shunya
 
+
+# Add safe directory for git to avoid dubious ownership warnings
+RUN git config --global --add safe.directory /shunya
+
+
 # Install basic dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -30,6 +35,12 @@ RUN git clone https://github.com/catchorg/Catch2.git && \
 # Install python requirements
 COPY requirements/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Download Git autocomplete script
+RUN curl -o /etc/bash_completion.d/git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
+
+# Enable autocomplete in Bash for all users
+RUN echo "source /etc/bash_completion.d/git-completion.bash" >> /etc/bash.bashrc
 
 ARG USER=ian
 ARG GROUP=prajnyanam

--- a/rundev.sh
+++ b/rundev.sh
@@ -52,14 +52,19 @@ DOCKER_USER="ian"
 GPU_FLAGS="--gpus=all"
 
 # Pull the latest version of the Docker image
-if [ "$ROOT_USER_FLAG" = true ]; then
+if [ "$DEV_ARG" = !true ]; then
   docker pull $IMAGE_NAME
 fi
 
 # Mount gitconfig file
 GIT_CONFIG_DIR="${HOME}/.gitconfig"
 GIT_FLAGS="-v $GIT_CONFIG_DIR:/etc/gitconfig:ro"
-SSH_FLAGS="-v $HOME/.ssh:/home/$DOCKER_USER/.ssh:ro"
+# Mount ssh keys base on user 
+if [ "$ROOT_USER_ARG" = true ]; then
+  SSH_FLAGS="-v $HOME/.ssh:/root/.ssh:ro"
+else
+  SSH_FLAGS="-v $HOME/.ssh:/home/$DOCKER_USER/.ssh:ro"
+fi
 
 # Script to start the docker and attach the codebase to the container
 docker run \


### PR DESCRIPTION
This MR updates the mounting path for SSH keys in the Docker to accommodate both root and ian users:

- If the user is root, SSH keys are mounted to /root/.ssh.

- If the user is ian, SSH keys are mounted to /home/ian/.ssh.